### PR TITLE
[MWPW-138979] Ability to centralize Gnav content

### DIFF
--- a/libs/blocks/global-footer/global-footer.js
+++ b/libs/blocks/global-footer/global-footer.js
@@ -13,7 +13,7 @@ import {
   getExperienceName,
   getAnalyticsValue,
   loadDecorateMenu,
-  getFederatedUrl,
+  fetchAndProcess,
   loadBaseStyles,
   yieldToMain,
   lanaLog,
@@ -21,7 +21,7 @@ import {
   toFragment,
 } from '../global-navigation/utilities/utilities.js';
 
-import { replaceKey, replaceText } from '../../features/placeholders.js';
+import { replaceKey } from '../../features/placeholders.js';
 
 const { miloLibs, codeRoot, locale } = getConfig();
 const base = miloLibs || codeRoot;
@@ -32,9 +32,7 @@ const CONFIG = {
 };
 
 class Footer {
-  constructor({ contentUrl, block, useFederatedContent } = {}) {
-    this.useFederatedContent = useFederatedContent;
-    this.contentUrl = contentUrl;
+  constructor({ block } = {}) {
     this.block = block;
     this.elements = {};
     this.init();
@@ -69,7 +67,13 @@ class Footer {
 
   decorateContent = () => logErrorFor(async () => {
     // Fetch footer content
-    this.body = await this.fetchContent();
+    const url = getMetadata('footer-source') || `${locale.contentRoot}/footer`;
+    this.useFederatedContent = url.includes('/federal/');
+    this.body = await fetchAndProcess({
+      url,
+      message: 'Error fetching footer content',
+      shouldDecorateLinks: false,
+    });
 
     if (!this.body) return;
 
@@ -106,30 +110,6 @@ class Footer {
 
     this.block.append(this.elements.footer);
   }, 'Failed to decorate footer content', 'errorType=error,module=global-footer');
-
-  fetchContent = async () => {
-    const resp = await fetch(`${this.contentUrl}.plain.html`);
-
-    if (!resp.ok) {
-      lanaLog({
-        message: `Failed to fetch footer content; content url: ${this.contentUrl}, status: ${resp.statusText}`,
-        tags: 'errorType=warn,module=global-footer',
-      });
-    }
-
-    const html = await resp.text();
-
-    if (!html) return null;
-
-    const parsedHTML = await replaceText(html, getFedsPlaceholderConfig());
-
-    try {
-      return new DOMParser().parseFromString(parsedHTML, 'text/html').body;
-    } catch (e) {
-      lanaLog({ message: 'Footer could not be instantiated', tags: 'errorType=error,module=global-footer' });
-      return null;
-    }
-  };
 
   loadMenuLogic = async () => {
     this.menuLogic = this.menuLogic || new Promise(async (resolve) => {
@@ -363,12 +343,7 @@ class Footer {
 
 export default function init(block) {
   try {
-    const contentUrl = getFederatedUrl(getMetadata('footer-source') || `${locale.contentRoot}/footer`);
-    const footer = new Footer({
-      block,
-      contentUrl,
-      useFederatedContent: contentUrl.includes('/federal/'),
-    });
+    const footer = new Footer({ block });
     return footer;
   } catch (e) {
     lanaLog({ message: 'Could not create footer', e });

--- a/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
+++ b/libs/blocks/global-navigation/features/breadcrumbs/breadcrumbs.js
@@ -1,5 +1,5 @@
 import { getMetadata, getConfig } from '../../../../utils/utils.js';
-import { toFragment, lanaLog } from '../../utilities/utilities.js';
+import { toFragment, lanaLog, getFederatedUrl } from '../../utilities/utilities.js';
 
 const metadata = {
   seo: 'breadcrumbs-seo',
@@ -67,7 +67,7 @@ const createBreadcrumbs = (element) => {
 
 const createWithBase = async (el) => {
   const element = el || toFragment`<div><ul></ul></div>`;
-  const url = getMetadata(metadata.base);
+  const url = getFederatedUrl(getMetadata(metadata.base));
   if (!url) return null;
   try {
     const resp = await fetch(`${url}.plain.html`);

--- a/libs/blocks/global-navigation/features/profile/dropdown.js
+++ b/libs/blocks/global-navigation/features/profile/dropdown.js
@@ -83,7 +83,6 @@ class ProfileDropdown {
       replaceKeyArray(
         ['profile-button', 'sign-out', 'view-account', 'manage-teams', 'manage-enterprise', 'profile-avatar'],
         getFedsPlaceholderConfig(),
-        'feds',
       ),
       window.adobeIMS.getProfile(),
     ]);

--- a/libs/blocks/global-navigation/features/search/gnav-search.js
+++ b/libs/blocks/global-navigation/features/search/gnav-search.js
@@ -46,7 +46,7 @@ class Search {
 
   async getLabels() {
     this.labels = {};
-    [this.labels.search, this.labels.clearResults, this.labels.tryAdvancedSearch] = await replaceKeyArray(['search', 'clear-results', 'try-advanced-search'], getFedsPlaceholderConfig(), 'feds');
+    [this.labels.search, this.labels.clearResults, this.labels.tryAdvancedSearch] = await replaceKeyArray(['search', 'clear-results', 'try-advanced-search'], getFedsPlaceholderConfig());
   }
 
   decorate() {

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -580,11 +580,7 @@ class Gnav {
     const activeModifier = itemHasActiveLink ? ` ${selectors.activeNavItem.slice(1)}` : '';
 
     // All dropdown decoration is delayed
-    const delayDropdownDecoration = ({
-      template,
-      isFederatedGnav,
-      isFederatedMenu,
-    } = {}) => {
+    const delayDropdownDecoration = ({ template } = {}) => {
       let decorationTimeout;
 
       const decorateDropdown = () => logErrorFor(async () => {
@@ -597,8 +593,7 @@ class Gnav {
           item,
           template,
           type: itemType,
-          isFederatedGnav,
-          isFederatedMenu,
+          isFederatedGnav: this.useFederatedContent,
         });
       }, 'Decorate dropdown failed', 'errorType=info,module=gnav');
 
@@ -641,11 +636,7 @@ class Gnav {
         });
         observer.observe(dropdownTrigger, { attributeFilter: ['aria-expanded'] });
 
-        delayDropdownDecoration({
-          template: triggerTemplate,
-          isFederatedGnav: this.useFederatedContent,
-          isFederatedMenu: item.closest('.feds') instanceof HTMLElement,
-        });
+        delayDropdownDecoration({ template: triggerTemplate });
         return triggerTemplate;
       }
       case 'primaryCta':

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -8,7 +8,6 @@ import {
 import {
   toFragment,
   getFedsPlaceholderConfig,
-  getFederatedUrl,
   federatePictureSources,
   getAnalyticsValue,
   decorateCta,
@@ -30,10 +29,10 @@ import {
   selectors,
   logErrorFor,
   lanaLog,
-  processMartechAttributeMetadata,
+  fetchAndProcess,
 } from './utilities/utilities.js';
 
-import { replaceKey, replaceKeyArray, replaceText } from '../../features/placeholders.js';
+import { replaceKey, replaceKeyArray } from '../../features/placeholders.js';
 
 const CONFIG = {
   icons: {
@@ -718,16 +717,16 @@ class Gnav {
 export default async function init(block) {
   try {
     const { locale } = getConfig();
-    const contentUrl = getFederatedUrl(getMetadata('gnav-source') || `${locale.contentRoot}/gnav`);
-    const resp = await fetch(`${contentUrl}.plain.html`);
-    const html = await resp.text();
-    if (!html) throw new Error('Gnav content could not be fetched');
-    const parsedHTML = await replaceText(html, getFedsPlaceholderConfig());
-    processMartechAttributeMetadata(parsedHTML);
+    const url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
+    const content = await fetchAndProcess({
+      url,
+      e: 'Error fetching gnav content',
+    });
+    if (!content) return null;
     const gnav = new Gnav({
-      content: new DOMParser().parseFromString(parsedHTML, 'text/html').body,
+      content,
       block,
-      useFederatedContent: contentUrl.includes('/federal/'),
+      useFederatedContent: url.includes('/federal/'),
     });
     gnav.init();
     block.setAttribute('daa-im', 'true');

--- a/libs/blocks/global-navigation/global-navigation.js
+++ b/libs/blocks/global-navigation/global-navigation.js
@@ -8,6 +8,8 @@ import {
 import {
   toFragment,
   getFedsPlaceholderConfig,
+  getFederatedUrl,
+  federatePictureSources,
   getAnalyticsValue,
   decorateCta,
   getExperienceName,
@@ -62,7 +64,7 @@ const signIn = () => {
 
 const decorateSignIn = async ({ rawElem, decoratedElem }) => {
   const dropdownElem = rawElem.querySelector(':scope > div:nth-child(2)');
-  const signInLabel = await replaceKey('sign-in', getFedsPlaceholderConfig(), 'feds');
+  const signInLabel = await replaceKey('sign-in', getFedsPlaceholderConfig());
   let signInElem;
 
   if (!dropdownElem) {
@@ -103,7 +105,6 @@ const decorateProfileTrigger = async ({ avatar }) => {
   const [label, profileAvatar] = await replaceKeyArray(
     ['profile-button', 'profile-avatar'],
     getFedsPlaceholderConfig(),
-    'feds',
   );
 
   const buttonElem = toFragment`
@@ -161,19 +162,21 @@ const closeOnClickOutside = (e) => {
 };
 
 class Gnav {
-  constructor(body, el) {
+  constructor({ content, block, useFederatedContent } = {}) {
+    this.content = content;
+    this.block = block;
+    this.useFederatedContent = useFederatedContent;
+
     this.blocks = {
       profile: {
-        rawElem: body.querySelector('.profile'),
+        rawElem: this.content.querySelector('.profile'),
         decoratedElem: toFragment`<div class="feds-profile"></div>`,
       },
       search: { config: { icon: CONFIG.icons.search } },
       breadcrumbs: { wrapper: '' },
     };
 
-    this.el = el;
-    this.body = body;
-    decorateLinks(this.body);
+    decorateLinks(this.content);
     this.elements = {};
   }
 
@@ -191,8 +194,8 @@ class Gnav {
       this.ims,
       this.addChangeEventListeners,
     ];
-    this.el.addEventListener('click', this.loadDelayed);
-    this.el.addEventListener('keydown', setupKeyboardNav);
+    this.block.addEventListener('click', this.loadDelayed);
+    this.block.addEventListener('keydown', setupKeyboardNav);
     setTimeout(this.loadDelayed, CONFIG.delays.loadDelayed);
     setTimeout(setupKeyboardNav, CONFIG.delays.keyboardNav);
     for await (const task of tasks) {
@@ -236,7 +239,8 @@ class Gnav {
         ${breadcrumbs}
       </div>`;
 
-    this.el.append(this.elements.curtain, this.elements.aside, this.elements.topnavWrapper);
+    if (this.useFederatedContent) federatePictureSources(this.elements.topnavWrapper);
+    this.block.append(this.elements.curtain, this.elements.aside, this.elements.topnavWrapper);
   };
 
   addChangeEventListeners = () => {
@@ -286,8 +290,8 @@ class Gnav {
   loadDelayed = async () => {
     this.ready = this.ready || new Promise(async (resolve) => {
       try {
-        this.el.removeEventListener('click', this.loadDelayed);
-        this.el.removeEventListener('keydown', this.loadDelayed);
+        this.block.removeEventListener('click', this.loadDelayed);
+        this.block.removeEventListener('keydown', this.loadDelayed);
         const [
           ProfileDropdown,
           Search,
@@ -438,7 +442,7 @@ class Gnav {
   };
 
   decorateGenericLogo = ({ selector, classPrefix, includeLabel = true, analyticsValue } = {}) => {
-    const rawBlock = this.body.querySelector(selector);
+    const rawBlock = this.content.querySelector(selector);
     if (!rawBlock) return '';
 
     // Get all non-image links
@@ -491,13 +495,13 @@ class Gnav {
     this.elements.aside = '';
     const promoPath = getMetadata('gnav-promo-source');
     if (!isDesktop.matches || !promoPath) {
-      this.el.classList.remove('has-promo');
+      this.block.classList.remove('has-promo');
       return this.elements.aside;
     }
 
     const { default: decorate } = await import('./features/aside/aside.js');
     if (!decorate) return this.elements.aside;
-    this.elements.aside = await decorate({ headerElem: this.el, promoPath });
+    this.elements.aside = await decorate({ headerElem: this.block, promoPath });
     return this.elements.aside;
   };
 
@@ -527,7 +531,7 @@ class Gnav {
     `;
 
     // Get all main menu items, but exclude any that are nested inside other features
-    const items = [...this.body.querySelectorAll('h2, p:only-child > strong > a, p:only-child > em > a')]
+    const items = [...this.content.querySelectorAll('h2, p:only-child > strong > a, p:only-child > em > a')]
       .filter((item) => CONFIG.features.every((feature) => !item.closest(`.${feature}`)));
 
     // Save number of items to decide whether a hamburger menu is required
@@ -576,7 +580,11 @@ class Gnav {
     const activeModifier = itemHasActiveLink ? ` ${selectors.activeNavItem.slice(1)}` : '';
 
     // All dropdown decoration is delayed
-    const delayDropdownDecoration = (template) => {
+    const delayDropdownDecoration = ({
+      template,
+      isFederatedGnav,
+      isFederatedMenu,
+    } = {}) => {
       let decorationTimeout;
 
       const decorateDropdown = () => logErrorFor(async () => {
@@ -589,6 +597,8 @@ class Gnav {
           item,
           template,
           type: itemType,
+          isFederatedGnav,
+          isFederatedMenu,
         });
       }, 'Decorate dropdown failed', 'errorType=info,module=gnav');
 
@@ -631,7 +641,11 @@ class Gnav {
         });
         observer.observe(dropdownTrigger, { attributeFilter: ['aria-expanded'] });
 
-        delayDropdownDecoration(triggerTemplate);
+        delayDropdownDecoration({
+          template: triggerTemplate,
+          isFederatedGnav: this.useFederatedContent,
+          isFederatedMenu: item.closest('.feds') instanceof HTMLElement,
+        });
         return triggerTemplate;
       }
       case 'primaryCta':
@@ -669,9 +683,9 @@ class Gnav {
   };
 
   decorateBreadcrumbs = async () => {
-    if (!this.el.classList.contains('has-breadcrumbs')) return null;
+    if (!this.block.classList.contains('has-breadcrumbs')) return null;
     if (this.elements.breadcrumbsWrapper) return this.elements.breadcrumbsWrapper;
-    const breadcrumbsElem = this.el.querySelector('.breadcrumbs');
+    const breadcrumbsElem = this.block.querySelector('.breadcrumbs');
     // Breadcrumbs are not initially part of the nav, need to decorate the links
     if (breadcrumbsElem) decorateLinks(breadcrumbsElem);
     const createBreadcrumbs = await loadBlock('../features/breadcrumbs/breadcrumbs.js');
@@ -680,7 +694,7 @@ class Gnav {
   };
 
   decorateSearch = () => {
-    const searchBlock = this.body.querySelector('.search');
+    const searchBlock = this.content.querySelector('.search');
 
     if (!searchBlock) return null;
 
@@ -696,7 +710,7 @@ class Gnav {
       </div>`;
 
     // Replace the aria-label value once placeholder is fetched
-    replaceKey('search', getFedsPlaceholderConfig(), 'feds').then((placeholder) => {
+    replaceKey('search', getFedsPlaceholderConfig()).then((placeholder) => {
       if (placeholder && placeholder.length) {
         this.blocks.search.config.trigger.setAttribute('aria-label', placeholder);
       }
@@ -710,21 +724,23 @@ class Gnav {
   };
 }
 
-export default async function init(header) {
-  const { locale } = getConfig();
-  // TODO locale.contentRoot is not the fallback we want if we implement centralized content
-  const url = getMetadata('gnav-source') || `${locale.contentRoot}/gnav`;
-  const resp = await fetch(`${url}.plain.html`);
-  const html = await resp.text();
-  if (!html) return null;
-  const parsedHTML = await replaceText(html, getFedsPlaceholderConfig(), undefined, 'feds');
-  processMartechAttributeMetadata(parsedHTML);
-
+export default async function init(block) {
   try {
-    const gnav = new Gnav(new DOMParser().parseFromString(parsedHTML, 'text/html').body, header);
+    const { locale } = getConfig();
+    const contentUrl = getFederatedUrl(getMetadata('gnav-source') || `${locale.contentRoot}/gnav`);
+    const resp = await fetch(`${contentUrl}.plain.html`);
+    const html = await resp.text();
+    if (!html) throw new Error('Gnav content could not be fetched');
+    const parsedHTML = await replaceText(html, getFedsPlaceholderConfig());
+    processMartechAttributeMetadata(parsedHTML);
+    const gnav = new Gnav({
+      content: new DOMParser().parseFromString(parsedHTML, 'text/html').body,
+      block,
+      useFederatedContent: contentUrl.includes('/federal/'),
+    });
     gnav.init();
-    header.setAttribute('daa-im', 'true');
-    header.setAttribute('daa-lh', `gnav|${getExperienceName()}|${document.body.dataset.mep}`);
+    block.setAttribute('daa-im', 'true');
+    block.setAttribute('daa-lh', `gnav|${getExperienceName()}|${document.body.dataset.mep}`);
     return gnav;
   } catch (e) {
     lanaLog({ message: 'Could not create global navigation.', e, tags: 'errorType=error,module=gnav' });

--- a/libs/blocks/global-navigation/utilities/menu/menu.js
+++ b/libs/blocks/global-navigation/utilities/menu/menu.js
@@ -313,6 +313,7 @@ const decorateMenu = (config) => logErrorFor(async () => {
 
   if (config.type === 'asyncDropdownTrigger') {
     const pathElement = config.item.querySelector('a');
+    const isFederatedMenu = pathElement?.href.includes('/federal/');
     if (!(pathElement instanceof HTMLElement)) return;
     let content;
 
@@ -336,7 +337,7 @@ const decorateMenu = (config) => logErrorFor(async () => {
       </div>`;
     decorateCrossCloudMenu(menuTemplate);
 
-    if (config.isFederatedMenu || config.isFederatedGnav) federatePictureSources(menuTemplate);
+    if (isFederatedMenu || config.isFederatedGnav) federatePictureSources(menuTemplate);
 
     // Content has been fetched dynamically, need to decorate links
     decorateLinks(menuTemplate);

--- a/libs/blocks/global-navigation/utilities/utilities.js
+++ b/libs/blocks/global-navigation/utilities/utilities.js
@@ -52,18 +52,27 @@ export function toFragment(htmlStrings, ...values) {
   return fragment;
 }
 
-let fedsContentRoot;
+let federatedContentRoot;
 export const getFederatedContentRoot = () => {
-  if (fedsContentRoot) return fedsContentRoot;
+  if (federatedContentRoot) return federatedContentRoot;
 
   const { origin } = window.location;
-  fedsContentRoot = origin;
+  const allowedOrigins = [
+    'https://www.adobe.com',
+    'https://business.adobe.com',
+    'https://blog.adobe.com',
+    'https://milo.adobe.com',
+  ];
+
+  federatedContentRoot = allowedOrigins.some((o) => origin === o)
+    ? origin
+    : 'https://www.adobe.com';
 
   if (origin.includes('localhost') || origin.includes('.hlx.')) {
-    fedsContentRoot = `https://main--federal--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
+    federatedContentRoot = `https://main--federal--adobecom.hlx.${origin.includes('hlx.live') ? 'live' : 'page'}`;
   }
 
-  return fedsContentRoot;
+  return federatedContentRoot;
 };
 
 export const getFederatedUrl = (url = '') => {

--- a/test/blocks/global-navigation/mocks/global-navigation.plain.js
+++ b/test/blocks/global-navigation/mocks/global-navigation.plain.js
@@ -25,6 +25,17 @@ export default `<div>
   </div>
 </div>
 <div>
+  <div class="large-menu section feds">
+    <div>
+      <div>
+        <h2 id="feds-menu">
+          <a href="/federal/feds-menu">FEDS Menu</a>
+        </h2>
+      </div>
+    </div>
+  </div>
+</div>
+<div>
   <h2 id="w-promo"><a href="https://business.adobe.com/">w/ Promo</a></h2>
   <ul>
     <li>
@@ -117,23 +128,23 @@ export default `<div>
         <picture>
           <source
             type="image/webp"
-            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
+            srcset="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=webply&optimize=medium"
             media="(min-width: 600px)"
           />
           <source
             type="image/webp"
-            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
+            srcset="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=webply&optimize=medium"
           />
           <source
             type="image/png"
-            srcset="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
+            srcset="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=2000&format=png&optimize=medium"
             media="(min-width: 600px)"
           />
           <img
             loading="lazy"
             alt=""
             type="image/png"
-            src="http://localhost:2000/test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
+            src="./test/blocks/global-navigation/mocks/media_linkgroup.png?width=750&format=png&optimize=medium"
             width="52"
             height="51"
           />

--- a/test/blocks/global-navigation/test-utilities.js
+++ b/test/blocks/global-navigation/test-utilities.js
@@ -3,7 +3,7 @@
 import sinon, { stub } from 'sinon';
 import { setViewport } from '@web/test-runner-commands';
 import initGnav from '../../../libs/blocks/global-navigation/global-navigation.js';
-import { getLocale, setConfig, loadStyle } from '../../../libs/utils/utils.js';
+import { setConfig, loadStyle } from '../../../libs/utils/utils.js';
 import defaultPlaceholders from './mocks/placeholders.js';
 import defaultProfile from './mocks/profile.js';
 import largeMenuMock from './mocks/large-menu.plain.js';
@@ -83,7 +83,6 @@ const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 export const config = {
   imsClientId: 'milo',
   codeRoot: '/libs',
-  contentRoot: `${window.location.origin}${getLocale(locales).prefix}`,
   locales,
 };
 
@@ -125,7 +124,7 @@ export const createFullGlobalNavigation = async ({
     // Intercept setTimeout and call the function immediately
     toFake: ['setTimeout'],
   });
-  setConfig(customConfig);
+  setConfig({ ...config, ...customConfig });
   await setViewport(viewports[viewport]);
   window.lana = { log: stub() };
   window.fetch = stub().callsFake((url) => {
@@ -135,6 +134,8 @@ export const createFullGlobalNavigation = async ({
     if (url.endsWith('large-menu-cross-cloud.plain.html')) { return mockRes({ payload: largeMenuCrossCloud }); }
     if (url.endsWith('large-menu-active.plain.html')) { return mockRes({ payload: largeMenuActiveMock }); }
     if (url.endsWith('large-menu-wide-column.plain.html')) { return mockRes({ payload: largeMenuWideColumnMock }); }
+    if (url.includes('main--federal--adobecom.hlx.page')
+      && url.endsWith('feds-menu.plain.html')) { return mockRes({ payload: largeMenuMock }); }
     if (url.includes('gnav')) { return mockRes({ payload: globalNavigation || globalNavigationMock }); }
     if (url.includes('correct-promo-fragment')) { return mockRes({ payload: correctPromoFragmentMock }); }
     if (url.includes('wrong-promo-fragment')) { return mockRes({ payload: '<div>Non-promo content</div>' }); }

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -34,7 +34,7 @@ describe('global navigation utilities', () => {
     expect(fragment2.tagName).to.equal('SPAN');
   });
 
-  // Nno tests for using the the live url and .hlx. urls
+  // No tests for using the the live url and .hlx. urls
   // as mocking window.location.origin is not possible
   describe('getFedsContentRoot', () => {
     it('should return content source for localhost', () => {

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -3,6 +3,8 @@ import sinon from 'sinon';
 import {
   toFragment,
   getFedsPlaceholderConfig,
+  federatePictureSources,
+  getFederatedContentRoot,
   getAnalyticsValue,
   decorateCta,
   hasActiveLink,
@@ -12,6 +14,7 @@ import {
   trigger,
   getExperienceName,
   logErrorFor,
+  getFederatedUrl,
 } from '../../../../libs/blocks/global-navigation/utilities/utilities.js';
 import { setConfig } from '../../../../libs/utils/utils.js';
 import { createFullGlobalNavigation, config } from '../test-utilities.js';
@@ -31,30 +34,72 @@ describe('global navigation utilities', () => {
     expect(fragment2.tagName).to.equal('SPAN');
   });
 
-  // TODO - no tests for using the the live url and .hlx. urls
+  // Nno tests for using the the live url and .hlx. urls
+  // as mocking window.location.origin is not possible
+  describe('getFedsContentRoot', () => {
+    it('should return content source for localhost', () => {
+      const contentSource = getFederatedContentRoot();
+      expect(contentSource).to.equal('https://main--federal--adobecom.hlx.page');
+    });
+  });
+
+  describe('federatePictureSources', () => {
+    it('should use federated content root for image sources', async () => {
+      const imgPath = 'test/blocks/global-navigation/mocks/media_medium_dropdown.png';
+      const template = toFragment`<picture>
+          <source
+            type="image/webp"
+            srcset="./${imgPath}"
+            media="(min-width: 600px)"/>
+          <source
+            type="image/webp"
+            srcset="./${imgPath}"/>
+          <source
+            type="image/png"
+            srcset="/${imgPath}"
+            media="(min-width: 600px)"/>
+          <img
+            loading="lazy"
+            alt=""
+            type="image/png"
+            src="/${imgPath}"/>
+        </picture>`;
+
+      federatePictureSources(template);
+      template.querySelectorAll('source, img').forEach((source) => {
+        const attr = source.hasAttribute('src') ? 'src' : 'srcset';
+        expect(source.getAttribute(attr)).to.equal(`https://main--federal--adobecom.hlx.page/${imgPath}`);
+      });
+    });
+  });
+
+  // No tests for using the the live url and .hlx. urls
   // as mocking window.location.origin is not possible
   describe('getFedsPlaceholderConfig', () => {
     it('should return contentRoot for localhost', () => {
-      const locale = { ietf: 'en-US', prefix: '' };
-      setConfig(locale);
-      const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig();
+      const locale = { locale: { ietf: 'en-US', prefix: '' } };
+      setConfig({ ...config, ...locale });
+      const placeholderConfig = { useCache: false };
+      const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig(placeholderConfig);
       expect(ietf).to.equal('en-US');
       expect(prefix).to.equal('');
-      expect(contentRoot).to.equal('https://main--milo--adobecom.hlx.page');
+      expect(contentRoot).to.equal('https://main--federal--adobecom.hlx.page/federal/globalnav');
     });
 
     it('should return a config object for a specific locale', () => {
-      setConfig({
+      const customConfig = {
         locales: {
           '': { ietf: 'en-US' },
           fi: { ietf: 'fi-FI' },
         },
         pathname: '/fi/',
-      });
-      const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig();
+      };
+      setConfig({ ...config, ...customConfig });
+      const placeholderConfig = { useCache: false };
+      const { locale: { ietf, prefix, contentRoot } } = getFedsPlaceholderConfig(placeholderConfig);
       expect(ietf).to.equal('fi-FI');
       expect(prefix).to.equal('/fi');
-      expect(contentRoot).to.equal('https://main--milo--adobecom.hlx.page/fi');
+      expect(contentRoot).to.equal('https://main--federal--adobecom.hlx.page/fi/federal/globalnav');
     });
   });
 
@@ -208,6 +253,49 @@ describe('global navigation utilities', () => {
 
       // Restore the original window.lana.log method
       window.lana.log = originalLanaLog;
+    });
+  });
+
+  describe('getFederatedUrl', () => {
+    it('should return the url if its not federated', () => {
+      expect(getFederatedUrl('https://adobe.com/foo-fragment.html')).to.equal(
+        'https://adobe.com/foo-fragment.html',
+      );
+
+      expect(getFederatedUrl('/foo-fragment.html')).to.equal(
+        '/foo-fragment.html',
+      );
+
+      expect(getFederatedUrl('/lu_de/foo-fragment.html')).to.equal(
+        '/lu_de/foo-fragment.html',
+      );
+    });
+
+    it('should return the federated url', () => {
+      expect(
+        getFederatedUrl('https://adobe.com/federal/foo-fragment.html'),
+      ).to.equal(
+        'https://main--federal--adobecom.hlx.page/federal/foo-fragment.html',
+      );
+      expect(
+        getFederatedUrl('https://adobe.com/lu_de/federal/gnav/foofooter.html'),
+      ).to.equal(
+        'https://main--federal--adobecom.hlx.page/lu_de/federal/gnav/foofooter.html',
+      );
+    });
+
+    it('should return the federated url for a relative link', () => {
+      expect(
+        getFederatedUrl('/federal/foo-fragment.html'),
+      ).to.equal(
+        'https://main--federal--adobecom.hlx.page/federal/foo-fragment.html',
+      );
+    });
+
+    it('should return the url for invalid urls', () => {
+      expect(getFederatedUrl('en-US/federal/')).to.equal('en-US/federal/');
+      expect(getFederatedUrl(null)).to.equal(null);
+      expect(getFederatedUrl(123121)).to.equal(123121);
     });
   });
 });

--- a/test/blocks/global-navigation/utilities/utilities.test.js
+++ b/test/blocks/global-navigation/utilities/utilities.test.js
@@ -292,6 +292,14 @@ describe('global navigation utilities', () => {
       );
     });
 
+    it('should return the federated url for a relative link including hashes and search params', () => {
+      expect(
+        getFederatedUrl('/federal/foo-fragment.html?foo=bar#test'),
+      ).to.equal(
+        'https://main--federal--adobecom.hlx.page/federal/foo-fragment.html?foo=bar#test',
+      );
+    });
+
     it('should return the url for invalid urls', () => {
       expect(getFederatedUrl('en-US/federal/')).to.equal('en-US/federal/');
       expect(getFederatedUrl(null)).to.equal(null);


### PR DESCRIPTION
### Description
Adds the possibility to centralise gnav content such as large menu's by supplying a link from the a project for centralised milo content such as https://main--federal--adobecom.hlx.live/federal/globalnav/drafts/osahin/gnav 

On (www.|business.|blog.|milo.)adobe.com this simply be mapped to `/federal/globalnav/drafts/osahin/gnav` and does not require any extra TLS handshake.

### Solution design
The overarching idea of this is that `https://main--federal--adobecom.hlx.live` serves as content hub for anything that is shared across consumers. In the (near) future 404s can be moved there, merch related content might make sense in there and I'm sure a bunch of use cases will pop up.

### Features added
While we added support for a bunch of use-cases, for now only strictly _shared_ content should live in the new content repository and the normal case should still be that gnav's live and are maintained by each consumer.

- Ability to fetch the global footer&navigation, menu's & base-breadcrumbs from a central location
- Fetches gnav/footer placeholders from `/federal/globalnav/placeholders` instead of `milo.adobe.com/placeholders?sheet=feds` which leads to a performance overhead


Resolves: [MWPW-138979](https://jira.corp.adobe.com/browse/MWPW-138979)
[MWPW-136659](https://jira.corp.adobe.com/browse/MWPW-136659)

**Test URLs:**
Further use-cases can be found in `SP>milo>ch_de>drafts>osahin>federalisation` & `SP>milo>drafts>osahin>federalisation`

Ensure to be on VPN when viewing those links. The `hlx.page` content is guarded
- Before: https://main--milo--adobecom.hlx.page/ch_de/drafts/osahin/federalisation/nav-and-footer
- After: https://mwpw-138979--milo--mokimo.hlx.page/ch_de/drafts/osahin/federalisation/nav-and-footer

- Before: https://main--milo--adobecom.hlx.page/drafts/osahin/federalisation/nav-and-footer
- After: https://mwpw-138979--milo--mokimo.hlx.page/drafts/osahin/federalisation/nav-and-footer
